### PR TITLE
Creating a DGL sampler that matches PyG/GLT sampling result

### DIFF
--- a/examples/pyg_sampler.py
+++ b/examples/pyg_sampler.py
@@ -12,7 +12,14 @@ import math
 class PyGSampler(dgl.dataloading.Sampler):
     r"""
     An example DGL sampler implementation that matches PyG/GLT sampler behavior. 
-    See issue https://github.com/alibaba/graphlearn-for-pytorch/issues/79 for the sampler difference with examples. 
+    The following differences need to be addressed: 
+    1.  PyG/GLT applies conv_i to edges in layer_i, and all subsequent layers, while DGL only applies conv_i to edges in layer_i. 
+        For instance, consider a path a->b->c. At layer 0, DGL updates only node b's embedding with a->b, but PyG/GLT updates both node b and c's embeddings.
+        Therefore, if we use h_i(x) to denote the hidden representation of node x at layer i, then the output h_2(c) is: 
+            DGL:     h_2(c) = conv_2(h_1(c), h_1(b)) = conv_2(h_0(c) + conv_1(h_0(b) + h_0(a)))
+            PyG/GLT: h_2(c) = conv_2(h_1(c), h_1(b)) = conv_2(conv_1(h_0(c) + h_0(b)) + conv_1(h_0(b) + h_0(a)))
+    2.  When creating blocks for layer i-1, DGL not only uses the destination nodes from layer i, but also includes all subsequent i+1 ... n layers' destination nodes as seed nodes.
+    More discussions and examples can be found here: https://github.com/alibaba/graphlearn-for-pytorch/issues/79. 
     """
     def __init__(self, fanouts):
         super().__init__()

--- a/examples/pyg_sampler.py
+++ b/examples/pyg_sampler.py
@@ -14,11 +14,14 @@ class PyGSampler(dgl.dataloading.Sampler):
     An example DGL sampler implementation that matches PyG/GLT sampler behavior. 
     The following differences need to be addressed: 
     1.  PyG/GLT applies conv_i to edges in layer_i, and all subsequent layers, while DGL only applies conv_i to edges in layer_i. 
-        For instance, consider a path a->b->c. At layer 0, DGL updates only node b's embedding with a->b, but PyG/GLT updates both node b and c's embeddings.
+        For instance, consider a path a->b->c. At layer 0, 
+        DGL updates only node b's embedding with a->b, but 
+        PyG/GLT updates both node b and c's embeddings.
         Therefore, if we use h_i(x) to denote the hidden representation of node x at layer i, then the output h_2(c) is: 
-            DGL:     h_2(c) = conv_2(h_1(c), h_1(b)) = conv_2(h_0(c) + conv_1(h_0(b) + h_0(a)))
-            PyG/GLT: h_2(c) = conv_2(h_1(c), h_1(b)) = conv_2(conv_1(h_0(c) + h_0(b)) + conv_1(h_0(b) + h_0(a)))
-    2.  When creating blocks for layer i-1, DGL not only uses the destination nodes from layer i, but also includes all subsequent i+1 ... n layers' destination nodes as seed nodes.
+            DGL:     h_2(c) = conv_2(h_1(c), h_1(b)) = conv_2(h_0(c), conv_1(h_0(b), h_0(a)))
+            PyG/GLT: h_2(c) = conv_2(h_1(c), h_1(b)) = conv_2(conv_1(h_0(c), h_0(b)), conv_1(h_0(b), h_0(a)))
+    2.  When creating blocks for layer i-1, DGL not only uses the destination nodes from layer i, 
+        but also includes all subsequent i+1 ... n layers' destination nodes as seed nodes.
     More discussions and examples can be found here: https://github.com/alibaba/graphlearn-for-pytorch/issues/79. 
     """
     def __init__(self, fanouts):

--- a/examples/pyg_sampler.py
+++ b/examples/pyg_sampler.py
@@ -1,0 +1,147 @@
+# Libraries required for PyGSampler
+import dgl
+
+# Libraries required for sanity checks
+from collections import Counter
+from igb.dataloader import IGBHeteroDGLDataset
+import torch
+import argparse
+import tqdm
+import math
+
+class PyGSampler(dgl.dataloading.Sampler):
+    r"""
+    An example DGL sampler implementation that matches PyG/GLT sampler behavior. 
+    See issue https://github.com/alibaba/graphlearn-for-pytorch/issues/79 for the sampler difference with examples. 
+    """
+    def __init__(self, fanouts):
+        super().__init__()
+        self.fanouts = fanouts
+
+    def sample(self, g, seed_nodes):
+        output_nodes = seed_nodes
+        subgs = []
+        previous_edges = {}
+        previous_seed_nodes = seed_nodes
+        for fanout in reversed(self.fanouts):
+            # Sample a fixed number of neighbors of the current seed nodes.
+            sg = g.sample_neighbors(seed_nodes, fanout)
+
+            # Before we add the edges, we need to first record the source nodes (of the current seed nodes)
+            # so that other edges' source nodes will not be included as next layer's seed nodes. 
+            temp = dgl.to_block(sg, previous_seed_nodes, include_dst_in_src=False)
+            seed_nodes = temp.srcdata[dgl.NID]
+
+            # We add all previously accumulated edges to this subgraph
+            for etype in previous_edges:
+                sg.add_edges(*previous_edges[etype], etype=etype)
+            
+            # This subgraph now contains all its new edges 
+            # and previously accumulated edges
+            # so we add the 
+            previous_edges = {}
+            for etype in sg.etypes:
+                previous_edges[etype] = sg.edges(etype=etype)
+
+            # Convert this subgraph to a message flow graph.
+            # we need to turn on the include_dst_in_src
+            # so that we get compatibility with DGL's OOTB GATConv. 
+            sg = dgl.to_block(sg, previous_seed_nodes, include_dst_in_src=True)
+
+            # for this layers seed nodes - 
+            # they will be our next layers' destination nodes
+            # so we add them to the collection of previous seed nodes. 
+            previous_seed_nodes = sg.srcdata[dgl.NID]
+            
+            # we insert the block to our list of blocks
+            subgs.insert(0, sg)
+            input_nodes = seed_nodes
+        return input_nodes, output_nodes, subgs
+
+
+# Sanity check
+def test_correct_layers(blocks, seed_nodes, ntypes, etypes):
+    """
+    To verify the correctness of this sampler, we need to make sure the following things at each layer i:
+    1. All previous edges (layer i+1, ..., layer n) are included in this layer. 
+        This ensures that DGL matches GLT/PyG in bullet point 1 of the issue list.  
+    2. All incremental new edges <src_i -> dst_i> must have the destination nodes dst_i as last layer's source node src_{i-1}. 
+        This ensures that DGL matches GLT/PyG in bullet point 2 of the issue list.
+
+    DGL's native sampler violates both rules, therefore it will not pass the two assertions. 
+    GLT sampler **with trim_to_layer** and the above PyGSampler will pass this test.  
+    """
+    edges = {etype: [] for etype in etypes}
+    last_layer_src_nodes = {ntype: nodes.tolist() for ntype, nodes in seed_nodes.items()}
+    for block in reversed(blocks):
+        src_nodes_copy = {}
+        for srctype, etype, dsttype in block.canonical_etypes:
+            srcids = block.srcdata[dgl.NID][srctype]
+            dstids = block.dstdata[dgl.NID][dsttype]
+            current_layer_edge_indices = [(srcids[srcid].item(), dstids[dstid].item()) for srcid, dstid in zip(*block.edges(etype=etype))]
+            current_layer_edge_counter = Counter(current_layer_edge_indices)
+            last_layer_edge_counter = Counter(edges[(srctype, etype, dsttype)])
+            
+            # make sure that all previous edges are in the current layer
+            assert last_layer_edge_counter - current_layer_edge_counter == {}, f"{dict(last_layer_edge_indices - current_layer_edge_indices)}"
+
+            # make sure that all newly-added edges' dstnodes are in-edges to last layer src nodes (this layer's seed/dst nodes)
+            assert all([
+                dstnode in last_layer_src_nodes[dsttype]
+                for _, dstnode in (current_layer_edge_counter - last_layer_edge_counter).keys()
+            ]), f"{current_layer_edge_counter - last_layer_edge_counter}, {last_layer_src_nodes[dsttype]}"
+                
+            src_nodes_copy[srctype] = srcids.tolist()
+            edges[(srctype, etype, dsttype)] = current_layer_edge_indices
+        last_layer_src_nodes = src_nodes_copy
+
+
+# We repeat the experiment several times to avoid edge cases
+def correctness_test(n_repeats, n_batches, batch_size, fan_outs, graph):
+    for _ in range(n_repeats):
+        sampler = PyGSampler(fan_outs)
+        # sampler = dgl.dataloading.MultiLayerNeighborSampler(fan_outs) # this will not pass the test
+        loader = dgl.dataloading.DataLoader(graph, {"paper": graph.nodes('paper')}, sampler, batch_size=batch_size, shuffle=True)
+        counter = 0
+        for _, seed_nodes, blocks in tqdm.tqdm(loader, total=min(n_batches, math.ceil(graph.nodes('paper').shape[0] / batch_size))):
+            if counter >= n_batches:
+                break
+            test_correct_layers(blocks, seed_nodes, graph.ntypes, graph.canonical_etypes)
+            counter += 1
+    print(f"Correctness test passed. Sampled {fan_outs} with random {n_batches * batch_size} nodes as seed nodes for {n_repeats} times.")
+
+
+if __name__ == "__main__":
+    # we perform some sanity checks here. 
+
+    # Prepare graphs
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--path', type=str, default='/data', 
+        help='path containing the datasets')
+    parser.add_argument('--dataset_size', type=str, default='tiny',
+        choices=['tiny', 'small', 'medium', 'large', 'full'], 
+        help='size of the datasets')
+    parser.add_argument('--num_classes', type=int, default=19, 
+        choices=[19, 2983], help='number of classes')
+    parser.add_argument('--in_memory', type=int, default=0, 
+        choices=[0, 1], help='0:read only mmap_mode=r, 1:load into memory')
+    parser.add_argument('--synthetic', type=int, default=0,
+        choices=[0, 1], help='0:nlp-node embeddings, 1:random')
+
+    args = parser.parse_args()
+    graph = IGBHeteroDGLDataset(args)[0]
+
+    # monotonically increasing fanouts
+    correctness_test(10, 64, 128, [10,15], graph)
+
+    # constant fanouts
+    correctness_test(10, 64, 128, [10,10], graph)
+
+    # monotonically decreasing fanouts
+    correctness_test(10, 64, 128, [15,10], graph)
+
+    # 3-layer, we experiment the same thing
+    correctness_test(10, 64, 128, [5,10,15], graph)
+    correctness_test(10, 64, 128, [10,10,10], graph)
+    correctness_test(10, 64, 128, [15,10,5], graph)
+    

--- a/igb/train_multi_hetero.py
+++ b/igb/train_multi_hetero.py
@@ -1,0 +1,231 @@
+import argparse, datetime
+import dgl
+import sklearn.metrics
+import torch, torch.nn as nn, torch.optim as optim
+import torch.multiprocessing as mp
+import time, tqdm, numpy as np
+from models import RGCN, RSAGE, RGAT
+from dataloader import IGBHeteroDGLDataset
+
+torch.manual_seed(0)
+dgl.seed(0)
+import warnings
+warnings.filterwarnings("ignore")
+
+
+
+
+def run(proc_id, devices, g, args):
+
+    dev_id = devices[proc_id]
+    dist_init_method = 'tcp://{master_ip}:{master_port}'.format(master_ip='127.0.0.1', master_port='12345')
+    if torch.cuda.device_count() < 1:
+        device = torch.device('cpu')
+        torch.distributed.init_process_group(
+            backend='gloo', init_method=dist_init_method, world_size=len(devices), rank=proc_id)
+    else:
+        torch.cuda.set_device(dev_id)
+        device = torch.device('cuda:' + str(dev_id))
+        torch.distributed.init_process_group(
+            backend='nccl', init_method=dist_init_method, world_size=len(devices), rank=proc_id)
+        
+    category = g.predict
+
+    sampler = dgl.dataloading.MultiLayerNeighborSampler(
+                [int(fanout) for fanout in args.fan_out.split(',')],
+                prefetch_node_feats={k: ['feat'] for k in g.ntypes},
+                prefetch_labels={category: ['label']})
+
+    # sampler = dgl.dataloading.NeighborSampler([4, 4])
+
+    train_nid = torch.nonzero(g.nodes[category].data['train_mask'], as_tuple=True)[0]
+    val_nid = torch.nonzero(g.nodes[category].data['val_mask'], as_tuple=True)[0]
+    test_nid = torch.nonzero(g.nodes[category].data['test_mask'], as_tuple=True)[0]
+    
+    train_dataloader = dgl.dataloading.DataLoader(
+        g, {category: train_nid}, sampler, device='cpu', use_ddp=True,
+        batch_size=args.batch_size,
+        shuffle=True, drop_last=False,
+        num_workers=args.num_workers)    
+
+    val_dataloader = dgl.dataloading.DataLoader(
+        g, {category: val_nid}, sampler, device='cpu', use_ddp=True,
+        batch_size=args.batch_size,
+        shuffle=False, drop_last=False,
+        num_workers=args.num_workers)
+
+    test_dataloader = dgl.dataloading.DataLoader(
+        g, {category: test_nid}, sampler, device='cpu', use_ddp=True,
+        batch_size=args.batch_size,
+        shuffle=False, drop_last=False,
+        num_workers=args.num_workers)
+
+    in_feats = g.ndata['feat'][category].shape[1]
+
+    model = None
+
+    if args.model_type == 'rgcn':
+        model = RGCN(g.etypes, in_feats, args.hidden_channels, args.num_classes, 
+            args.num_layers).to(device)
+    if args.model_type == 'rsage':
+        model = RSAGE(g.etypes, in_feats, args.hidden_channels, args.num_classes, 
+            args.num_layers).to(device)
+    if args.model_type == 'rgat':
+        model = RGAT(g.etypes, in_feats, args.hidden_channels, args.num_classes, 
+            args.num_layers, args.num_heads).to(device)
+
+    if device == torch.device('cpu'):
+        model = torch.nn.parallel.DistributedDataParallel(model, device_ids=None, output_device=None)
+    else:
+        model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[device], output_device=device, find_unused_parameters=True)
+
+    if proc_id == 0:
+        param_size = 0
+        for param in model.parameters():
+            param_size += param.nelement() * param.element_size()
+        buffer_size = 0
+        for buffer in model.buffers():
+            buffer_size += buffer.nelement() * buffer.element_size()
+
+        size_all_mb = (param_size + buffer_size) / 1024**2
+        print('model size: {:.3f}MB'.format(size_all_mb))
+
+    loss_fcn = nn.CrossEntropyLoss().to(device)
+    optimizer = optim.Adam(model.parameters(), 
+        lr=args.learning_rate, weight_decay=args.decay)
+    
+    # TODO: In the future, need to also make step_size and gamma as configurable HP
+    sched = optim.lr_scheduler.StepLR(optimizer, step_size=args.sched_stepsize, gamma=args.sched_gamma)
+
+     # Training loop
+    best_accuracy = 0
+    training_start = time.time()
+    for epoch in range(args.epochs):
+        # Loop over the dataloader to sample the computation dependency graph as a list of
+        # blocks.
+        epoch_loss = 0
+        epoch_start = time.time()
+        model.train()
+        accs = []
+
+        gpu_mem_alloc = []
+        for step, (input_nodes, seeds, blocks) in enumerate(train_dataloader):
+            blocks = [block.to(device) for block in blocks]
+            batch_inputs = blocks[0].srcdata['feat']
+            batch_labels = blocks[-1].dstdata['label'][category]
+
+            batch_pred = model(blocks, batch_inputs)
+            loss = loss_fcn(batch_pred, batch_labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            epoch_loss += loss.detach()
+            accs.append(sklearn.metrics.accuracy_score(batch_labels.cpu().numpy(), 
+                batch_pred.argmax(1).detach().cpu().numpy())*100)
+            gpu_mem_alloc.append(
+                torch.cuda.max_memory_allocated(device=device) / 1000000
+                if torch.cuda.is_available()
+                else 0
+            )
+        
+        epoch_acc = sum(accs) / len(accs)
+        epoch_gpu_mem = sum(gpu_mem_alloc) / len(gpu_mem_alloc)
+
+        model.eval()
+        if proc_id == 0:
+            if epoch%args.log_every == 0:
+                predictions = []
+                labels = []
+                with torch.no_grad():
+                    for _, _, blocks in val_dataloader:
+                        blocks = [block.to(device) for block in blocks]
+                        inputs = blocks[0].srcdata['feat']
+                        labels.append(blocks[-1].dstdata['label'][category].cpu().numpy())
+                        predictions.append(model(blocks, inputs).argmax(1).cpu().numpy())
+                    predictions = np.concatenate(predictions)
+                    labels = np.concatenate(labels)
+                    val_acc = sklearn.metrics.accuracy_score(labels, predictions)*100
+                    if best_accuracy < val_acc:
+                        best_accuracy = val_acc
+                        if args.model_save:
+                            torch.save(model.state_dict(), args.modelpath)
+
+                print(
+                    "Epoch {:03d} | Loss {:.4f} | Train Acc {:.2f} | Val Acc {:.2f} | Time {} | GPU {:.1f} MB".format(
+                        epoch,
+                        epoch_loss,
+                        epoch_acc,
+                        val_acc,
+                        str(datetime.timedelta(seconds = int(time.time() - epoch_start))),
+                        epoch_gpu_mem
+                    )
+                )
+
+        sched.step()
+
+    model.eval()
+    if proc_id == 0:
+        predictions = []
+        labels = []
+        with torch.no_grad():
+            for _, _, blocks in test_dataloader:
+                blocks = [block.to(device) for block in blocks]
+                inputs = blocks[0].srcdata['feat']
+                labels.append(blocks[-1].dstdata['label'][category].cpu().numpy())
+                predictions.append(model(blocks, inputs).argmax(1).cpu().numpy())
+            predictions = np.concatenate(predictions)
+            labels = np.concatenate(labels)
+            test_acc = sklearn.metrics.accuracy_score(labels, predictions)*100
+        print("Test Acc {:.2f}%".format(test_acc))
+        print("Total time taken " + str(datetime.timedelta(seconds = int(time.time() - training_start))))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    # Loading dataset
+    parser.add_argument('--path', type=str, default='/mnt/nvme14/IGB260M/', 
+        help='path containing the datasets')
+    parser.add_argument('--dataset_size', type=str, default='tiny',
+        choices=['tiny', 'small', 'medium', 'large', 'full'], 
+        help='size of the datasets')
+    parser.add_argument('--num_classes', type=int, default=19, 
+        choices=[19, 2983], help='number of classes')
+    parser.add_argument('--in_memory', type=int, default=0, 
+        choices=[0, 1], help='0:read only mmap_mode=r, 1:load into memory')
+    parser.add_argument('--synthetic', type=int, default=0,
+        choices=[0, 1], help='0:nlp-node embeddings, 1:random')
+
+    # Model
+    parser.add_argument('--model_type', type=str, default='rgat',
+                        choices=['rgat', 'rsage', 'rgcn'])
+    parser.add_argument('--modelpath', type=str, default='deletethis.pt')
+    parser.add_argument('--model_save', type=int, default=0)
+
+    # Model parameters 
+    parser.add_argument('--fan_out', type=str, default='10,15')
+    parser.add_argument('--batch_size', type=int, default=10240)
+    parser.add_argument('--num_workers', type=int, default=4)
+    parser.add_argument('--hidden_channels', type=int, default=128)
+    parser.add_argument('--learning_rate', type=int, default=0.01)
+    parser.add_argument('--decay', type=int, default=0.001)
+    parser.add_argument('--epochs', type=int, default=20)
+    parser.add_argument('--num_layers', type=int, default=6)
+    parser.add_argument('--num_heads', type=int, default=4)
+
+    parser.add_argument("--sched_stepsize", type=int, default=25)
+    parser.add_argument("--sched_gamma", type=float, default=0.25)
+
+    parser.add_argument('--log_every', type=int, default=5)
+    parser.add_argument('--device', type=int, default=0)
+
+    parser.add_argument('--gpu_devices', type=str, default='0,1,2,3')
+    args = parser.parse_args()
+
+    gpu_idx = [int(fanout) for fanout in args.gpu_devices.split(',')]
+    num_gpus = len(gpu_idx)
+    dataset = IGBHeteroDGLDataset(args)
+    g = dataset[0]
+    print(g)
+
+    start = time.time()
+    mp.spawn(run, args=(gpu_idx, g, args,), nprocs=num_gpus)


### PR DESCRIPTION
Hi, when trying out the codes in DGL and PyG/[GLT](https://github.com/alibaba/graphlearn-for-pytorch), we notice that there are two [differences](https://github.com/alibaba/graphlearn-for-pytorch/issues/79) in DGL vs. PyG/GLT neighbor sampler that leads to mathematical inequivalence in the GATConv layer. Thus, we're providing this custom DGL sampler here to mimic the behavior of PyG/GLT samplers. With this sampler, we hope to match DGL and PyG/GLT behavior, so that we could perform a more rigorous apple-to-apple comparison between the DGL/PyG training results on this dataset. 

This sampler is verified on IGBH-Tiny with various fanouts. 