### PR TITLE
Changes for supporting non interactive environments

### DIFF
--- a/igb/download.py
+++ b/igb/download.py
@@ -58,14 +58,14 @@ def check_md5sum(dataset_type, dataset_size, filename):
         raise Exception(" md5sum verification failed!.")
         
 
-def download_dataset(path, dataset_type, dataset_size):
+def download_dataset(path, dataset_type, dataset_size, confirm_download):
     output_directory = path
     url = dataset_urls[dataset_type][dataset_size]
     filename = path + "/igb_" + dataset_type + "_" + dataset_size + ".tar.gz"
     # check if the dataset is already downloaded
     if os.path.exists(filename):
         print("Dataset already downloaded.")
-    elif decide_download(url):
+    elif confirm_download or decide_download(url):
         data = ur.urlopen(url)
         size = int(data.info()["Content-Length"])
         chunk_size = 1024*1024
@@ -103,6 +103,10 @@ if __name__ == '__main__':
     parser.add_argument('--dataset_size', type=str, default='tiny',
         choices=['tiny', 'small', 'medium'], 
         help='size of the datasets')
+    parser.add_argument(
+        "--confirm-download",
+        action="store_true",
+        help="To skip the user prompt for confirming the download, which is useful for Docker detached mode.")
     args = parser.parse_args()    
-    download_dataset(args.path, args.dataset_type, args.dataset_size)
+    download_dataset(args.path, args.dataset_type, args.dataset_size, args.confirm_download)
     

--- a/igb/download.py
+++ b/igb/download.py
@@ -58,7 +58,7 @@ def check_md5sum(dataset_type, dataset_size, filename):
         raise Exception(" md5sum verification failed!.")
         
 
-def download_dataset(path, dataset_type, dataset_size, confirm_download):
+def download_dataset(path, dataset_type, dataset_size, confirm_download=False):
     output_directory = path
     url = dataset_urls[dataset_type][dataset_size]
     filename = path + "/igb_" + dataset_type + "_" + dataset_size + ".tar.gz"

--- a/igb/download.py
+++ b/igb/download.py
@@ -106,6 +106,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--confirm-download",
         action="store_true",
+        default=False,
         help="To skip the user prompt for confirming the download, which is useful for Docker detached mode.")
     args = parser.parse_args()    
     download_dataset(args.path, args.dataset_type, args.dataset_size, args.confirm_download)


### PR DESCRIPTION
Hi team,

This PR enables users to pass the command line argument `--confirm-download` when integrating the IGB dataset download into their automation workflows. This feature is particularly useful in non-interactive environments, such as Docker in detached mode. Without this option, users may encounter the following error:

```
191.4 This will download 1.93GB. Will you proceed? (y/N) Traceback (most recent call last):
191.4   File "/home/cmuser/CM/repos/local/cache/3947f65073814957/inference/graph/R-GAT/tools/download_igbh_test.py", line 34, in <module>
191.4     download.download_dataset(
191.4   File "/home/cmuser/venv/cm/lib/python3.10/site-packages/igb/download.py", line 68, in download_dataset
191.4     elif confirm_download or decide_download(url):
191.4   File "/home/cmuser/venv/cm/lib/python3.10/site-packages/igb/download.py", line 13, in decide_download
191.4     return input("This will download %.2fGB. Will you proceed? (y/N) " % (size)).lower() == "y"
191.4 EOFError: EOF when reading a line

```